### PR TITLE
roll back changes to subsp parsing

### DIFF
--- a/data_processing/DigiApp/format_data_for_specify/HERB/formatDataForSpecify.py
+++ b/data_processing/DigiApp/format_data_for_specify/HERB/formatDataForSpecify.py
@@ -34,85 +34,80 @@ def parse_taxonfullname(row):
     fullname = str(row.get('taxonfullname', '')).strip()
     rankid = row.get('rankid', None)
 
-    # Initialize result
     result = {'genus': '', 'species': '', 'subspecies': '', 'variety': '', 'forma': ''}
 
-    if not fullname or fullname.lower() == 'nan':
+    if not fullname:
         return pd.Series(result)
 
     parts = fullname.split()
-    result['genus'] = parts[0]  # always genus (unless family)
+    result['genus'] = parts[0]  # always genus (unless only family)
 
     # Remove genus if rankid == 140 (Family)
     if rankid == 140:
         result['genus'] = ''
-        return pd.Series(result)
 
-    # If rankid = 180 (Genus-level), only genus is used
+    # If rankid=180, only genus is used
     if rankid == 180:
         return pd.Series(result)
 
-    # -------- helpers --------
+    # helper: normalized token for comparisons (treat '×' as 'x', remove trailing dot)
     def _norm(tok):
         return tok.replace('×', 'x').lower().rstrip('.')
 
-    def _collect_hybrid_epithet(start_idx):
-        """
-        Collect tokens for one epithet, handling hybrids:
-        - 'x name' or 'name x name'
-        """
-        if start_idx >= len(parts):
-            return []
-
+    # helper: return tokens from start index until next rank marker or an uppercase token (likely author)
+    def _collect_zone(start_idx):
         zone = []
-
-        # leading hybrid
-        if _norm(parts[start_idx]) == 'x' and start_idx + 1 < len(parts):
-            return parts[start_idx:start_idx + 2]
-
-        zone.append(parts[start_idx])
-
-        # internal hybrid: name x name
-        if start_idx + 2 < len(parts) and _norm(parts[start_idx + 1]) == 'x':
-            zone.extend(parts[start_idx + 1:start_idx + 3])
-
+        i = start_idx
+        while i < len(parts):
+            n = _norm(parts[i])
+            # stop if we hit an infraspecific rank marker
+            if n in ('subsp', 'ssp', 'var', 'forma', 'f'):
+                break
+            # stop at an author-like token (starts with uppercase or open parenthesis)
+            if parts[i][0].isupper() or parts[i][0] == '(':
+                break
+            zone.append(parts[i])
+            i += 1
         return zone
 
+    # helper: format an epithet zone into the desired value (handles hybrids)
     def _format_epithet(zone):
-        return ' '.join(zone) if zone else ''
+        if not zone:
+            return ''
+        # leading hybrid marker: 'x brucheri'
+        if _norm(zone[0]) == 'x':
+            return zone[0] + (' ' + zone[1] if len(zone) > 1 else '')
+        # hybrid inside zone: 'danica x officinalis' or 'arcuata x vulgaris'
+        if any(_norm(t) == 'x' for t in zone):
+            return ' '.join(zone)
+        # otherwise, just first epithet
+        return zone[0]
 
-    # -------- subspecies (rankid 230, positional) ----------
-    if rankid == 230:
-        # species: start at index 1
-        species_zone = _collect_hybrid_epithet(1)
-        result['species'] = _format_epithet(species_zone)
-
-        # subspecies: immediately after species
-        subsp_start = 1 + len(species_zone)
-        if subsp_start < len(parts) and not parts[subsp_start][0].isupper():
-            subspecies_zone = _collect_hybrid_epithet(subsp_start)
-            result['subspecies'] = _format_epithet(subspecies_zone)
-
-        return pd.Series(result)
-
-    # -------- species for rankid >= 220 ----------
+    # -------- species: extract for every rankid >= 220 ----------
     if rankid is not None and rankid >= 220:
-        species_zone = _collect_hybrid_epithet(1)
+        species_zone = _collect_zone(1)
         result['species'] = _format_epithet(species_zone)
 
-    # -------- infraspecifics (variety and forma) ----------
-    if rankid == 240:  # variety
+    # -------- infraspecifics according to rankid ----------
+    if rankid == 230:  # subspecies
+        for i, t in enumerate(parts):
+            if _norm(t) in ('subsp', 'ssp'):
+                subs_zone = _collect_zone(i + 1)
+                result['subspecies'] = _format_epithet(subs_zone)
+                break
+
+    elif rankid == 240:  # variety
         for i, t in enumerate(parts):
             if _norm(t) == 'var':
-                var_zone = _collect_hybrid_epithet(i + 1)
+                var_zone = _collect_zone(i + 1)
                 result['variety'] = _format_epithet(var_zone)
                 break
 
     elif rankid == 260:  # forma
         for i, t in enumerate(parts):
             if _norm(t) in ('forma', 'f'):
-                f_zone = _collect_hybrid_epithet(i + 1)
-                result['forma'] = _format_epithet(f_zone)
+                f_zone = _collect_zone(i + 1)
+                result['forma'] = f_zone[0] if f_zone else ''
                 break
 
     return pd.Series(result)

--- a/data_processing/DigiApp/format_data_for_specify/PIOF/formatDataForSpecify.py
+++ b/data_processing/DigiApp/format_data_for_specify/PIOF/formatDataForSpecify.py
@@ -29,69 +29,72 @@ os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
 # Ensure the archive folder exists
 os.makedirs(archive_folder, exist_ok=True)
 
-# Parse taxonfullname into genus, species, and subspecies based on rankid
-def parse_taxon_name(row):
+# Separate the taxonomic fields based on rank_terms found in 'taxonfullname' and extract qualifiers
+def parse_taxonfullname(row):
+    fullname = str(row.get('taxonfullname', '')).strip()
+    rankid = row.get('rankid', None)
+
     result = {'genus': '', 'species': '', 'subspecies': ''}
 
-    fullname = str(row.get('taxonfullname', '')).strip()
-    rankid = row.get('rankid')
-
-    if not fullname or fullname.lower() == 'nan':
+    if not fullname:
         return pd.Series(result)
 
     parts = fullname.split()
-    result['genus'] = parts[0]
+    result['genus'] = parts[0]  # always genus (unless only family)
 
-    # Family
+    # Remove genus if rankid == 140 (Family)
     if rankid == 140:
         result['genus'] = ''
-        return pd.Series(result)
 
-    # Genus
+    # If rankid=180, only genus is used
     if rankid == 180:
         return pd.Series(result)
 
+    # helper: normalized token for comparisons (treat '×' as 'x', remove trailing dot)
     def _norm(tok):
         return tok.replace('×', 'x').lower().rstrip('.')
-    
-    def _collect_hybrid_epithet(start_idx):
-        """
-        Collects tokens for a single epithet:
-        - 'name'
-        - 'x name'
-        - 'name x name'
-        Stops after completing one epithet.
-        """
-        if start_idx >= len(parts):
-            return []
 
+    # helper: return tokens from start index until next rank marker or an uppercase token (likely author)
+    def _collect_zone(start_idx):
         zone = []
-
-        # leading hybrid: x name
-        if parts[start_idx].lower() == 'x' and start_idx + 1 < len(parts):
-            return parts[start_idx:start_idx + 2]
-
-        zone.append(parts[start_idx])
-
-        # internal hybrid: name x name
-        if start_idx + 2 < len(parts) and parts[start_idx + 1].lower() == 'x':
-            zone.extend(parts[start_idx + 1:start_idx + 3])
-
+        i = start_idx
+        while i < len(parts):
+            n = _norm(parts[i])
+            # stop if we hit an infraspecific rank marker
+            if n in ('subsp', 'ssp'):
+                break
+            # stop at an author-like token (starts with uppercase or open parenthesis)
+            if parts[i][0].isupper() or parts[i][0] == '(':
+                break
+            zone.append(parts[i])
+            i += 1
         return zone
 
-    # ---------- species ----------
-    if rankid >= 220 and len(parts) > 1:
-        species_zone = _collect_hybrid_epithet(1)
-        result['species'] = ' '.join(species_zone)
+    # helper: format an epithet zone into the desired value (handles hybrids)
+    def _format_epithet(zone):
+        if not zone:
+            return ''
+        # leading hybrid marker: 'x brucheri'
+        if _norm(zone[0]) == 'x':
+            return zone[0] + (' ' + zone[1] if len(zone) > 1 else '')
+        # hybrid inside zone: 'danica x officinalis' or 'arcuata x vulgaris'
+        if any(_norm(t) == 'x' for t in zone):
+            return ' '.join(zone)
+        # otherwise, just first epithet
+        return zone[0]
 
-    # ---------- subspecies ----------
-    if rankid == 230:
-        subsp_start = 1 + len(species_zone)
+    # -------- species: extract for every rankid >= 220 ----------
+    if rankid is not None and rankid >= 220:
+        species_zone = _collect_zone(1)
+        result['species'] = _format_epithet(species_zone)
 
-        # stop if next token looks like an author
-        if subsp_start < len(parts) and not parts[subsp_start][0].isupper():
-            subspecies_zone = _collect_hybrid_epithet(subsp_start)
-            result['subspecies'] = ' '.join(subspecies_zone)
+    # -------- infraspecifics according to rankid ----------
+    if rankid == 230:  # subspecies
+        for i, t in enumerate(parts):
+            if _norm(t) in ('subsp', 'ssp'):
+                subs_zone = _collect_zone(i + 1)
+                result['subspecies'] = _format_epithet(subs_zone)
+                break
 
     return pd.Series(result)
 
@@ -199,7 +202,7 @@ for filename in os.listdir(folder_path):
             )
         
         # Assign taxonomic fields from 'taxonfullname' to 'genus', 'species', etc.
-        df[['genus', 'species', 'subspecies']] = df.apply(parse_taxon_name, axis=1)
+        df[['genus', 'species', 'subspecies']] = df.apply(parse_taxonfullname, axis=1)
 
 
         df[[


### PR DESCRIPTION
parse subspecies in DigiApp exports using rankid and expecting 'subsp' or 'ssp' verbiage